### PR TITLE
handle error cases

### DIFF
--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -61,7 +61,7 @@ def get_all_packages() -> dict:
                     package = str(f).replace('.py', '')
                     packages.setdefault(package, []).append(dist)
         except ValueError:
-            sys.stderr.write('python-popularity-contect: Skipping package {0} due to ValueError.\n'.format(dist.name))
+            sys.stderr.write('python-popularity-contest: Skipping package {0} due to ValueError.\n'.format(dist.name))
     return packages
 
 

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -61,7 +61,7 @@ def get_all_packages() -> dict:
                     package = str(f).replace('.py', '')
                     packages.setdefault(package, []).append(dist)
         except ValueError:
-            sys.stderr.write('Skipping package {0} due to ValueError.\n'.format(f.name))
+            sys.stderr.write('Skipping package {0} due to ValueError.\n'.format(dist.name))
     return packages
 
 

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -63,10 +63,12 @@ def get_all_packages() -> dict:
                         package = str(f).replace('.py', '')
                         packages.setdefault(package, []).append(dist)
             else:
-                sys.stderr.write('python-popularity-contest: Skipping package {0} due to no files being present in dist.\n'.format(dist.name))
+                pass
+                # sys.stderr.write('python-popularity-contest: Skipping package {0} due to no files being present in dist.\n'.format(dist.name))
         except ValueError:
-            sys.stderr.write('python-popularity-contest: Skipping package {0} due to ValueError.\n'.format(dist.name))
-            traceback.print_exception(*sys.exc_info(), file=sys.stderr)
+            pass
+            # sys.stderr.write('python-popularity-contest: Skipping package {0} due to ValueError.\n'.format(dist.name))
+            # traceback.print_exception(*sys.exc_info(), file=sys.stderr)
     return packages
 
 

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -48,7 +48,6 @@ def get_all_packages() -> dict:
         have a lot of packages installed on a slow filesystem (like NFS).
     """
     packages = {}
-    skipped_packages = []
     for dist in distributions():
         try:
             if dist.files:

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -62,7 +62,7 @@ def get_all_packages() -> dict:
                         package = str(f).replace('.py', '')
                         packages.setdefault(package, []).append(dist)
             else:
-                sys.stderr.write('Skipping package {0} due to no files being present.\n'.format(dist.name))
+                sys.stderr.write('python-popularity-contest: Skipping package {0} due to no files being present in dist.\n'.format(dist.name))
         except ValueError:
             sys.stderr.write('python-popularity-contest: Skipping package {0} due to ValueError.\n'.format(dist.name))
     return packages

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -12,6 +12,7 @@ have been imported. stdlib and local modules are ignord.
 import atexit
 import os
 import sys
+import traceback
 
 from importlib_metadata import distributions
 from statsd import StatsClient
@@ -47,6 +48,7 @@ def get_all_packages() -> dict:
         have a lot of packages installed on a slow filesystem (like NFS).
     """
     packages = {}
+    skipped_packages = []
     for dist in distributions():
         try:
             if dist.files:
@@ -65,6 +67,7 @@ def get_all_packages() -> dict:
                 sys.stderr.write('python-popularity-contest: Skipping package {0} due to no files being present in dist.\n'.format(dist.name))
         except ValueError:
             sys.stderr.write('python-popularity-contest: Skipping package {0} due to ValueError.\n'.format(dist.name))
+            traceback.print_exception(*sys.exc_info(), file=sys.stderr)
     return packages
 
 

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -49,17 +49,20 @@ def get_all_packages() -> dict:
     packages = {}
     for dist in distributions():
         try:
-            for f in dist.files:
-                if f.name == '__init__.py':
-                    # If an __init__.py file is present, the parent
-                    # directory should be counted as a package
-                    package = str(f.parent).replace('/',  '.')
-                    packages.setdefault(package, []).append(dist)
-                elif f.name == str(f):
-                    # If it is a top level file, it should be
-                    # considered as a package by itself
-                    package = str(f).replace('.py', '')
-                    packages.setdefault(package, []).append(dist)
+            if dist.files:
+                for f in dist.files:
+                    if f.name == '__init__.py':
+                        # If an __init__.py file is present, the parent
+                        # directory should be counted as a package
+                        package = str(f.parent).replace('/',  '.')
+                        packages.setdefault(package, []).append(dist)
+                    elif f.name == str(f):
+                        # If it is a top level file, it should be
+                        # considered as a package by itself
+                        package = str(f).replace('.py', '')
+                        packages.setdefault(package, []).append(dist)
+            else:
+                sys.stderr.write('Skipping package {0} due to no files being present.\n'.format(dist.name))
         except ValueError:
             sys.stderr.write('python-popularity-contest: Skipping package {0} due to ValueError.\n'.format(dist.name))
     return packages

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -61,7 +61,7 @@ def get_all_packages() -> dict:
                     package = str(f).replace('.py', '')
                     packages.setdefault(package, []).append(dist)
         except ValueError:
-            sys.stderr.write('Skipping package {0} due to ValueError.\n'.format(dist.name))
+            sys.stderr.write('python-popularity-contect: Skipping package {0} due to ValueError.\n'.format(dist.name))
     return packages
 
 

--- a/popularity_contest/reporter.py
+++ b/popularity_contest/reporter.py
@@ -48,17 +48,20 @@ def get_all_packages() -> dict:
     """
     packages = {}
     for dist in distributions():
-        for f in dist.files:
-            if f.name == '__init__.py':
-                # If an __init__.py file is present, the parent
-                # directory should be counted as a package
-                package = str(f.parent).replace('/',  '.')
-                packages.setdefault(package, []).append(dist)
-            elif f.name == str(f):
-                # If it is a top level file, it should be
-                # considered as a package by itself
-                package = str(f).replace('.py', '')
-                packages.setdefault(package, []).append(dist)
+        try:
+            for f in dist.files:
+                if f.name == '__init__.py':
+                    # If an __init__.py file is present, the parent
+                    # directory should be counted as a package
+                    package = str(f.parent).replace('/',  '.')
+                    packages.setdefault(package, []).append(dist)
+                elif f.name == str(f):
+                    # If it is a top level file, it should be
+                    # considered as a package by itself
+                    package = str(f).replace('.py', '')
+                    packages.setdefault(package, []).append(dist)
+        except ValueError:
+            sys.stderr.write('Skipping package {0} due to ValueError.\n'.format(f.name))
     return packages
 
 


### PR DESCRIPTION
howdy howdy @yuvipanda !  

we're debugging this, and i found during my testing that there's a strange edge case where a package doesn't have files where they're expected to be and `package_metadata.distributions` complains and fails:

```
Exception ignored in atexit callback: <function report_popularity at 0x7f065fa65da0>
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/popularity_contest/reporter.py", line 105, in report_popularity
    libraries = get_used_libraries(initial_modules, current_modules)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/popularity_contest/reporter.py", line 74, in get_used_libraries
    all_packages = get_all_packages()
                   ^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/popularity_contest/reporter.py", line 51, in get_all_packages
    for f in dist.files:
             ^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/importlib_metadata/__init__.py", line 512, in files
    return skip_missing_files(
           ^^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/importlib_metadata/_functools.py", line 102, in wrapper
    return func(param, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/importlib_metadata/__init__.py", line 510, in skip_missing_files
    return list(filter(lambda path: path.locate().exists(), package_paths))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/importlib_metadata/__init__.py", line 549, in <genexpr>
    .relative_to(self.locate_file('').resolve())
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/pathlib.py", line 730, in relative_to
    raise ValueError("{!r} is not in the subpath of {!r}"
ValueError: '/srv/conda/envs/notebook/etc/jupyter/nbconfig/notebook.d/ipydatagrid.json' is not in the subpath of '/srv/conda/envs/notebook/lib/python3.11/site-packages' OR one path is relative and the other is absolute.
```

so, this at least keeps things from crashing hard.  i could also replace the `sys.stderr.write()` call with `pass`...